### PR TITLE
Add NiFi Volume Fstab Record

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -114,3 +114,9 @@ nifi_custom_log_levels: []
 # keytool arguments
 nifi_server_alias: nifi-server
 nifi_keytool_dname: "CN=data.ona.io, OU=DATA, O=ONA, L=NY, S=NY, C=US"
+
+# Nifi volume settings
+nifi_volume_mount_point: /mnt/nifi-volume
+nifi_volume_device: /dev/xvdf
+nifi_volume_fs_type: ext4
+nifi_volume_mount_opts: defaults,discard

--- a/tasks/config.yaml
+++ b/tasks/config.yaml
@@ -69,6 +69,14 @@
     - { src: "{{ nifi_major_version }}/nifi.sh.j2", dest: "{{ nifi_home }}/bin/nifi.sh" }
     - { src: "{{ nifi_major_version }}/nifi-env.sh.j2", dest: "{{ nifi_home }}/bin/nifi-env.sh" }
 
+- name: Ensure nifi volume fstab record exists
+  mount:
+    path: "{{ nifi_volume_mount_point }}"
+    src: "{{ nifi_volume_device }}"
+    fstype: "{{ nifi_volume_fs_type }}"
+    state: mounted
+    opts: "{{ nifi_volume_mount_opts }}"
+
 - name: Ensure NiFi is running
   service: name=nifi state=started enabled=yes
 


### PR DESCRIPTION
Add a task for ensuring the Nifi volume mount is present in `/etc/fstab`.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>