### PR TITLE
Switch to archive.apache.org for Archive Downloads

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,7 +7,7 @@
 
 - name: Download binaries
   get_url:
-    url: http://www-eu.apache.org/dist/nifi/{{ nifi_version }}/{{ nifi_archive_name }}
+    url: http://archive.apache.org/dist/nifi/{{ nifi_version }}/{{ nifi_archive_name }}
     checksum: "{{ nifi_checksum[nifi_version] }}"
     dest: "{{ nifi_base_dir }}"
 


### PR DESCRIPTION
Switch to using archive.apache.org for downloading the NiFi binary
archive. Do this because www-eu.apache.org doesn't seem to have all the
archive versions.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>