### PR TITLE
Copy Custom Nifi Scripts from a git Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ If `nifi_is_secure` is `True` you must also include
     nifi_log_level_org_wali: WARN
     nifi_custom_log_levels: []
 
+    # Nifi custom scripts repositories. An array
+    nifi_git_scripts:
+     - git_repo: # The repository to download from
+       git_branch: # The branch/version to download
+       git_key: # Optional ssh key to use to clone the repository
+       destination: # the destination in the Nifi Home folder to copy the downloaded repository to
+
 ## Backup / Restore
 
 Backup/Restore via duplicity is enabled by default - daily backups are performed and stored locally without any other configuration.  The variable which controls this is:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -260,3 +260,6 @@ nifi_backup_profiles:
       - "{{ _move_post_restore_dirs_command }}"
       - rm -rf "{{ _temp_backup_dir }}"
       - systemctl start nifi
+        #
+# Custom Nifi scripts from a repository
+nifi_git_scripts: []

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -85,6 +85,14 @@
     - { src: "config/nifi.sh.j2", dest: "{{ nifi_home }}/bin/nifi.sh" }
     - { src: "config/nifi-env.sh.j2", dest: "{{ nifi_home }}/bin/nifi-env.sh" }
 
+- name: Load nifi scripts from script repos
+  git:
+    repo: "{{ item.git_repo }}"
+    version: "{{ item.git_branch }}"
+    keyfile: "{{ item.git_key | default('') }}"
+    dest: "{{ nifi_home }}/{{ item.destination }}"
+  with_items: "{{ nifi_git_scripts }}"
+
 - name: Create file system
   filesystem:
     fstype: "{{ nifi_volume_fs_type }}"


### PR DESCRIPTION
Since we cannot download individual files or folders from a git repo, clone the entire repository to a directory inside the Nifi home directory

closes https://github.com/onaio/playbooks/issues/1130