### PR TITLE
Nifi backup restore split into safe/unsafe options

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,21 @@ Backup/Restore via duplicity is enabled by default - daily backups are performed
 nifi_backup_enabled: True
 ```
 
-> In order to do a clean backup of the flowfile repository the nifi service must be taken offline - the default time period to do this is midnight system time.
+> By default, unsafe backups are taken of nifi at midnight system time every day.  Because nifi stays online, there is a small chance the flowfiles or even the flows
+> could be corrupted in the backup if they're being modified at the same time.
+> In order to do a safe backup of the flowfile repository the nifi service must be taken offline - this is disruptive so is scheduled for just once-a-week.
+> The default time period to do safe backups is every Monday at 9PM system time, which is a weekday and outside working hours in most of the world assuming GMT.
+> To disable safe backups set `nifi_safe_backup_schedule` to `false` or `null`.
 
 To store backups in S3 instead, something like the following should be set:
 
 ```yaml
 nifi_backup_target: "s3://{{ vault_s3_aws_access_key }}:{{ vault_s3_aws_secret_key }}@s3.eu-west-1.amazonaws.com/{{ project_name }}-nifi-backup"
-nifi_backup_schedule: "0 0 * * 0"
+nifi_backup_schedule: "0 0 * * *" # Midnight
 nifi_backup_max_age: "7D"
+
+nifi_safe_backup_schedule: "0 21 * * 1" # 9PM Monday
+nifi_safe_backup_max_age: "30D"
 ```
 
 See [Stouts.backup](https://github.com/Stouts/Stouts.backup) for more information about the options available.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -169,17 +169,23 @@ nifi_test_if_publicly_accessible: false
 
 nifi_backup_enabled: True
 
-nifi_backup_schedule: "0 0 * * 0"
+nifi_backup_id: "nifi.{% if 'nifi' in groups %}{{ groups['nifi'].index(inventory_hostname) + 1 }}{% else %}{{ groups['all'].index(inventory_hostname) + 1 }}{% endif %}"
+
+nifi_backup_schedule: "0 0 * * *" # Midnight
 nifi_backup_max_age: "7D"
+
+nifi_safe_backup_schedule: "0 21 * * 1" # 9PM Monday
+nifi_safe_backup_max_age: "30D"
+
 nifi_backup_target: "file:///var/backup/nifi"
 nifi_backup_s3_using_http: False
 
-nifi_backup_sources: "{{ [nifi_etc_dir, nifi_conf_dir, nifi_database_repository, nifi_flowfile_repository] + nifi_content_repositories + nifi_provenance_repositories }}"
-nifi_flows_backup_sources: "{{ [nifi_etc_dir, nifi_conf_dir, nifi_database_repository] }}"
-nifi_flowfiles_backup_sources: "{{ [nifi_flowfile_repository] + nifi_content_repositories + nifi_provenance_repositories }}"
+nifi_flow_backup_sources: "{{ [nifi_etc_dir, nifi_conf_dir] }}"
+nifi_repository_backup_sources: "{{ [nifi_flowfile_repository, nifi_database_repository] + nifi_content_repositories + nifi_provenance_repositories }}"
+nifi_backup_sources: "{{ nifi_flow_backup_sources + nifi_repository_backup_sources }}"
 
-_nifi_backup_id: "{% if 'nifi' in groups %}{{ nifi_backup_id | default(groups['nifi'].index(inventory_hostname) + 1) }}{% else %}{{ nifi_backup_id | default(groups['all'].index(inventory_hostname) + 1) }}{% endif %}"
-_nifi_backup_target: "{{ nifi_backup_target }}/nifi.{{ _nifi_backup_id }}"
+_nifi_backup_target: "{{ nifi_backup_target }}/{{ nifi_backup_id }}.unsafe"
+_nifi_safe_backup_target: "{{ nifi_backup_target }}/{{ nifi_backup_id }}.safe"
 
 #
 # All this crazyness is necessary because duplicity really doesn't like cloning more than one directory tree
@@ -189,21 +195,38 @@ _nifi_backup_target: "{{ nifi_backup_target }}/nifi.{{ _nifi_backup_id }}"
 _temp_backup_dir: "/tmp/backup/nifi"
 _pre_restore_dir: "/tmp/pre_restore/nifi"
 
-_populate_backup_dir_command: "{% for source in nifi_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
+#
+# Backup Commands
+#
+
+_ensure_empty_backup_dir_command: rm -rf "{{ _temp_backup_dir }}" || mkdir -p "{{ _temp_backup_dir }}"
+
+_nifi_link_for_backup_command: "{% for source in nifi_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
    {% set source_parent = (source | dirname) %}
    mkdir -p \"{{ _temp_backup_dir }}{{ source_parent }}\" && \\\n
    ln -s \"{{ source }}\" \"{{ _temp_backup_dir }}{{ source }}\"
    {% endfor %}"
-_move_pre_restore_dirs_command: "{% for source in nifi_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
+
+_cleanup_backup_dir_command: rm -rf "{{ _temp_backup_dir }}"
+
+#
+# Restore Commands
+#
+
+_ensure_empty_prerestore_dir_command: rm -rf "{{ _pre_restore_dir }}" || mkdir -p "{{ _pre_restore_dir }}"
+
+_nifi_save_prerestore_command: "{% for source in nifi_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
    {% set source_parent = (source | dirname) %}
    mkdir -p \"{{ _pre_restore_dir }}{{ source_parent }}\" && \\\n
    mv \"{{ source }}\" \"{{ _pre_restore_dir }}{{ source_parent }}\"
    {% endfor %}"
-_move_post_restore_dirs_command: "{% for source in nifi_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
+
+_nifi_flows_restore_command: "{% for source in nifi_flow_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
    mv \"{{ _temp_backup_dir }}{{ source }}\" \"{{ source }}\"
    {% endfor %}"
-_clear_post_restore_flowfiles_dirs_command: "{% for source in nifi_flowfiles_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
-   rm -rf \"{{ _temp_backup_dir }}{{ source }}/\"* || true
+
+_nifi_repositories_restore_command: "{% for source in nifi_repository_backup_sources %}{% if loop.index > 1 %} && \\\n{% endif %}
+   mv \"{{ _temp_backup_dir }}{{ source }}\" \"{{ source }}\"
    {% endfor %}"
 
 _nifi_backup_s3_param: "{% if nifi_backup_s3_using_http | bool %}DUPL_PARAMS=\"$DUPL_PARAMS --s3-unencrypted-connection\"{% endif %}"
@@ -211,7 +234,7 @@ _nifi_copy_links_param: "DUPL_PARAMS=\"$DUPL_PARAMS --copy-links\""
 
 nifi_backup_profiles:
 
-  - name: nifi
+  - name: nifi_unsafe
     schedule: "{{ nifi_backup_schedule }}"
     max_age: "{{ nifi_backup_max_age }}"
     source:  "{{ _temp_backup_dir }}"
@@ -220,30 +243,27 @@ nifi_backup_profiles:
       - "{{ _nifi_backup_s3_param }}"
       - "{{ _nifi_copy_links_param }}"
     pre_actions:
-      - systemctl stop nifi
-      - rm -rf "{{ _temp_backup_dir }}" || mkdir -p "{{ _temp_backup_dir }}"
-      - "{{ _populate_backup_dir_command }}"
+      - "{{ _ensure_empty_backup_dir_command }}"
+      - "{{ _nifi_link_for_backup_command }}"
     post_actions:
-      - rm -rf "{{ _temp_backup_dir }}"
-      - systemctl start nifi
+      - "{{ _cleanup_backup_dir_command }}"
 
-  - name: nifi_restore
+  - name: nifi_safe
+    schedule: "{{ nifi_safe_backup_schedule }}"
+    max_age: "{{ nifi_safe_backup_max_age }}"
     source:  "{{ _temp_backup_dir }}"
-    target: "{{ _nifi_backup_target }}"
+    target: "{{ _nifi_safe_backup_target }}"
     params:
       - "{{ _nifi_backup_s3_param }}"
       - "{{ _nifi_copy_links_param }}"
     pre_actions:
       - systemctl stop nifi
-      - rm -rf "{{ _pre_restore_dir }}" || mkdir -p "{{ _pre_restore_dir }}"
-      - "{{ _move_pre_restore_dirs_command }}"
-      - rm -rf "{{ _temp_backup_dir }}" || true
+      - "{{ _ensure_empty_backup_dir_command }}"
+      - "{{ _nifi_link_for_backup_command }}"
     post_actions:
-      - "{{ _move_post_restore_dirs_command }}"
-      - rm -rf "{{ _temp_backup_dir }}"
+      - "{{ _cleanup_backup_dir_command }}"
       - systemctl start nifi
 
-  # Flows-only restore
   - name: nifi_flows_restore
     source:  "{{ _temp_backup_dir }}"
     target: "{{ _nifi_backup_target }}"
@@ -252,13 +272,29 @@ nifi_backup_profiles:
       - "{{ _nifi_copy_links_param }}"
     pre_actions:
       - systemctl stop nifi
-      - rm -rf "{{ _pre_restore_dir }}" || mkdir -p "{{ _pre_restore_dir }}"
-      - "{{ _move_pre_restore_dirs_command }}"
-      - rm -rf "{{ _temp_backup_dir }}" || true
+      - "{{ _ensure_empty_prerestore_dir_command }}"
+      - "{{ _nifi_save_prerestore_command }}"
+      - "{{ _ensure_empty_backup_dir_command }} || true"
     post_actions:
-      - "{{ _clear_post_restore_flowfiles_dirs_command }}"
-      - "{{ _move_post_restore_dirs_command }}"
-      - rm -rf "{{ _temp_backup_dir }}"
+      - "{{ _nifi_flows_restore_command }}"
+      - "{{ _cleanup_backup_dir_command }}"
+      - systemctl start nifi
+
+  - name: nifi_full_restore
+    source:  "{{ _temp_backup_dir }}"
+    target: "{{ _nifi_backup_target }}"
+    params:
+      - "{{ _nifi_backup_s3_param }}"
+      - "{{ _nifi_copy_links_param }}"
+    pre_actions:
+      - systemctl stop nifi
+      - "{{ _ensure_empty_prerestore_dir_command }}"
+      - "{{ _nifi_save_prerestore_command }}"
+      - "{{ _ensure_empty_backup_dir_command }} || true"
+    post_actions:
+      - "{{ _nifi_flows_restore_command }}"
+      - "{{ _nifi_repositories_restore_command }}"
+      - "{{ _cleanup_backup_dir_command }}"
       - systemctl start nifi
         #
 # Custom Nifi scripts from a repository

--- a/molecule/backup-restore/converge.yml
+++ b/molecule/backup-restore/converge.yml
@@ -5,6 +5,6 @@
     - role: ./nifi
       vars:
         nifi_web_http_host: "0.0.0.0"
-        nifi_backup_id: "molecule_test"
+        nifi_backup_id: "nifi.molecule_test"
         nifi_backup_target: "s3://dev_minio_access_key:dev_minio_secret_key@nifi_s3:9000/bucketa"
         nifi_backup_s3_using_http: true

--- a/molecule/backup-restore/verify.yml
+++ b/molecule/backup-restore/verify.yml
@@ -43,14 +43,15 @@
 - name: Backup from NiFi A
   hosts: nifi_a
   tasks:
-    - shell: nifi-backup.sh
+    - shell: nifi-backup.sh unsafe
+    - shell: nifi-backup.sh safe
 
-- name: Restore to NiFi B
+- name: Restore Flows to NiFi B
   hosts: nifi_b
   tasks:
-    - shell: nifi-restore.sh
+    - shell: nifi-restore.sh unsafe flows
 
-- name: Check NiFi B
+- name: Check Flows on NiFi B
   hosts: nifi_b
   tasks:
 
@@ -70,12 +71,47 @@
         headers:
           Content-Type: application/json
 
-    - name: Check flowfile repo file exists
+    - name: Check flowfile exists
       stat:
         path: "/opt/nifi/nifi-current/flowfile_repository/file_{{ test_group_id }}"
       register: result
 
-    - name: Fail if file doesn't exist
+    - name: Fail if flowfile exists
+      fail:
+        msg: "Flowfile repository file /opt/nifi/nifi-current/flowfile_repository/file_{{ test_group_id }} exists but should not!"
+      when: (result.stat.exists | bool)
+
+- name: Restore Full to NiFi B
+  hosts: nifi_b
+  tasks:
+    - shell: nifi-restore.sh safe full
+
+- name: Check Flows and Repositories on NiFi B
+  hosts: nifi_b
+  tasks:
+
+    - name: Wait for NiFi API B
+      uri:
+          url: http://localhost:8080/nifi-api/process-groups/root/process-groups
+          method: GET
+          status_code: 200
+      register: result
+      until: result.status == 200
+      retries: 60
+      delay: 5
+
+    - uri:
+        url: http://localhost:8080/nifi-api/process-groups/{{ test_group_id }}
+        method: GET
+        headers:
+          Content-Type: application/json
+
+    - name: Check flowfile exists
+      stat:
+        path: "/opt/nifi/nifi-current/flowfile_repository/file_{{ test_group_id }}"
+      register: result
+
+    - name: Fail if flowfile doesn't exist
       fail:
         msg: "Flowfile repository file /opt/nifi/nifi-current/flowfile_repository/file_{{ test_group_id }} does not exist!"
       when: not (result.stat.exists | bool)

--- a/tasks/install_toolkit.yml
+++ b/tasks/install_toolkit.yml
@@ -28,3 +28,11 @@
     state: link
     owner: "{{ nifi_user }}"
     group: "{{ nifi_group }}"
+
+- name: Create Java Home Helper Script
+  template:
+    src: "with-java-home.sh.j2"
+    dest: "{{ nifi_server_bin_dir[ansible_distribution]|default('/usr/bin') }}/with-java-home.sh"
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    mode: 755

--- a/templates/nifi-backup.sh.j2
+++ b/templates/nifi-backup.sh.j2
@@ -1,3 +1,6 @@
 #!/bin/sh
-
-duply nifi backup
+if [ -z "$1" ]; then
+    echo "A nifi backup type of 'safe' or 'unsafe' must be specified!"
+    exit 1
+fi
+duply "nifi_$1" backup

--- a/templates/nifi-restore.sh.j2
+++ b/templates/nifi-restore.sh.j2
@@ -1,8 +1,11 @@
 #!/bin/sh
-
-RESTORE_TYPE=nifi
-if [ -n "$1" ]; then
-	RESTORE_TYPE=nifi_flows
+if [ -z "$1" ]; then
+    echo "A nifi backup type of 'safe' or 'unsafe' must be specified!"
+    exit 1
+fi
+if [ -z "$2" ]; then
+    echo "A nifi restore type of 'flows' or 'full' must be specified!"
+    exit 1
 fi
 
-duply "${RESTORE_TYPE}_restore" pre && duply nifi restore && duply "${RESTORE_TYPE}_restore" post
+duply "nifi_$2_restore" pre && duply "nifi_$1" restore && duply "nifi_$2_restore" post

--- a/templates/with-java-home.sh.j2
+++ b/templates/with-java-home.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/sh
+export JAVA_HOME="$(java -XshowSettings:properties -version 2>&1 | grep 'java.home' | sed 's/.*=\s*//')"
+"$@"


### PR DESCRIPTION
I tried to address the two outstanding issues from here for nifi backup/restore:
https://github.com/onaio/ansible-nifi/pull/9

For #1 - the NiFi toolkit backup appears to be broken?, at least for 1.11 - looking at the source code it fails to identify important /etc/nifi directories where we store flow state (and is actually a pretty dumb script, the only magic is parsing the .conf files directly).  So we can't use the toolkit for backup right now.

For #2 - refactored the backup into safe/unsafe backups that happen at different schedules.  NiFi really isn't designed to be backed up while online, but generally I think it'll work if the instance is pretty idle.  As a less-aggressive default, we can do unsafe online backups daily but have a fallback weekly clean backup at a convenient time.
