### PR TITLE
Generate NiFi EMQTT certificates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -328,3 +328,4 @@ nifi_emqtt_secure_password:
 nifi_emqtt_cert_dir:
 nifi_emqtt_kestore_file_dest:
 nifi_create_mqtt_certs: false
+certificate_attributes: "/C=SC/ST=Some State/L=Some City/O=Some Company/OU=Some Department/CN=example.com"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -322,3 +322,57 @@ nifi_java_home: /usr/lib/jvm/java-8-openjdk-amd64/jre
 nifi_all_parameter_contexts_result_file: /tmp/all_parameter_contexts_result.json
 nifi_api_base_url: http://localhost:{{ nifi_web_http_port }}/nifi-api
 nifi_parameter_contexts:
+nifi_emqtt_certificate_authority_cert: |
+  -----BEGIN CERTIFICATE-----
+  MIIDfjCCAmYCCQDUvVVl3t4gNzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMC
+  S0UxEDAOBgNVBAgMB05haXJvYmkxEDAOBgNVBAcMB05haXJvYmkxDDAKBgNVBAoM
+  A09uYTEQMA4GA1UECwwHVGVzdGluZzEPMA0GA1UEAwwGb25hLmlvMRwwGgYJKoZI
+  hvcNAQkBFg1sc2ltYmFAb25hLmlvMB4XDTIwMDcwMzA4MTcyOVoXDTMwMDcwMTA4
+  MTcyOVowgYAxCzAJBgNVBAYTAktFMRAwDgYDVQQIDAdOYWlyb2JpMRAwDgYDVQQH
+  DAdOYWlyb2JpMQwwCgYDVQQKDANPbmExEDAOBgNVBAsMB1Rlc3RpbmcxDzANBgNV
+  BAMMBm9uYS5pbzEcMBoGCSqGSIb3DQEJARYNbHNpbWJhQG9uYS5pbzCCASIwDQYJ
+  KoZIhvcNAQEBBQADggEPADCCAQoCggEBAMA+hjOD0vRBfiIryVmC5LrUt+5Zyvok
+  xvggcZQMSi0+/7shXM1ylDGP0O/Mjsy+ITdx3XgOF19UlRzxkwib/+XKD29436M7
+  OGYKtq0C3UNMHxuZJpYCgt/vX6sJmAep4ln1LO/KE0hndy5OP+bxXb1OzmnuUIae
+  VmceyBVvXtk2hMKcypCukewp2SP1aUGYRpRLPDiMq7E/VhXaCbljqp3v7+I2GvlE
+  ONh+tdwUxqZvjk2N0clNDGEKp4peR6d6MH7aH3q3mKas8uIClbclTWwU6pMH9i2g
+  GpOk86Wo477UfWpHB/iCnESzrvuHVopsaY2pmmhlPhmH7PhounDgsBMCAwEAATAN
+  BgkqhkiG9w0BAQsFAAOCAQEAPtvx+p+sBZA9aWmhjvDsgfQA5OrcOoa/L5Tm6wdx
+  2o+88AgjON1xvIdCHOQw94z7sGbV4Ez1pj4r553HtwJGGhjrzIRtlZaMuT9LEMdr
+  DmppuM7ozyLaitciciHiYbASr0OQ0CU+7iRUFBIzjw+bJIcHDVsIk5r8WpQAbVmE
+  BMry/TefWeaWdOxjdqXFiy3oEJHZp2Y7sShMnXtCruAKGIYgZ9NAEEyfLq9VumFm
+  w1K70GVBORcJjpJQSEmSAIcX+XORzK3OkJnFmPC2/3ZdWGbuSY05bfBUc7522A3L
+  AHIfi9ba4WrMfMcBmDc8EyjHisdZPOTOc1jQh5ffgWgmQA==
+  -----END CERTIFICATE-----
+nifi_emqtt_certificate_authority_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIEogIBAAKCAQEAwD6GM4PS9EF+IivJWYLkutS37lnK+iTG+CBxlAxKLT7/uyFc
+  zXKUMY/Q78yOzL4hN3HdeA4XX1SVHPGTCJv/5coPb3jfozs4Zgq2rQLdQ0wfG5km
+  lgKC3+9fqwmYB6niWfUs78oTSGd3Lk4/5vFdvU7Oae5Qhp5WZx7IFW9e2TaEwpzK
+  kK6R7CnZI/VpQZhGlEs8OIyrsT9WFdoJuWOqne/v4jYa+UQ42H613BTGpm+OTY3R
+  yU0MYQqnil5Hp3owftofereYpqzy4gKVtyVNbBTqkwf2LaAak6TzpajjvtR9akcH
+  +IKcRLOu+4dWimxpjamaaGU+GYfs+Gi6cOCwEwIDAQABAoIBAQCfGl/4/I23hwh8
+  AV8XzMO+eFRtWDUrxwpAyqEVVQKC5dPCLL9gbQaG6i6Sd+prOqPE/mC7fnYLeLYc
+  CTaV9n3X0N3rdM8pidaIZS+AipFSpApOzfZoSlXEPZkgtcTz+r6Rkt8I6WYCE1dI
+  pIwwduwMw88DTq+oahy6JXiUfOKzwwLgYP1J9XNWtAJ+jgkR18zEMgrOTLEfs08m
+  IOqgDRIuMI+OidjAnB6C+LizIHu3dYagT1PrhVOiO1gIZeKhb+g47XJkyMMpAJ9o
+  knCe/0feT9DYB1LCK/XmHjP4FsPbWxI0LDIwKGT411EUdWMifkU7fESa9IHmEok8
+  bAzNR3nxAoGBAOJBP8wbqTYfKmUCWjqQEhwQW399iVNjETDxWsJAZqOf1rjKziaV
+  bUV16t/+40wL42yUzA1vPFTymV/AIvW3NSMLYVQ9aTNfcbmknf3npJrdRJtEvIiS
+  OQHtmRPofdo//poLUQc5AIY2uON3j8OQaeHBYvNlSLZ0TS1YtbShob0pAoGBANmE
+  oBQrLhqJ5hkAoEbiHZXguso5E/O82DTtq8xI3vX1GCBI3kLU7r9lPjunLuNyLpy4
+  x90smj9es6/+/Zf+aGpPaLY8LDgtLI/R4VLXj1pvebMlRNcaUiKVYoQQW1N+IfDy
+  5LLAOQqHEiAl8NOf/bBuq2bjH94Ty28htgJhoq7bAn8vuZO7eho3UFug8t4VfE5V
+  nR2vxsswy7TUnhSG5Q7BdPXWBPF3Mg3amQTyOtG3OMrAHKLuMoiHYqT3jY/SRNLw
+  kXX2Tv3h2EAk6JRq+nG+OO4/0j/yjuV3gqbHjEL/xn/t/nUZEO0LYn+de5rXpZ6w
+  ABrfPH4Z/m5JIm0xrOZxAoGAMQghYYp+QQM2uAoZFwFfc+qNkIofQkEeZ4fvwwPm
+  JoFSJ+zlFSGUk9ZJmf7Mpf6WHUPV4bhtKL27OX/8QCfb96Lg0rtrqFoegmjoJtlq
+  ehNI1qYfB3Hqc9tCssxRGdgD5KGMBfMoqIPcBR0oVTvqXrwDrRSjmVbS88EgmxbR
+  KiMCgYEArYUgbHqQypaq/WE2Dln32WeDPhbFjg2s6fOqiWsLx6cJk+N7cCz3/Wpm
+  yhAW+v3qWPQpnaCVkF3kgqViRX2AKWITBn2G/vktlHwj2FCJq3Q8quWacokE5EFZ
+  nOFJoIuOBE2Vx0fmGOru4tDSnXxbqRUqkuieAEaQ4028B1nGTXc=
+  -----END RSA PRIVATE KEY-----
+nifi_emqtt_secure_password: "emqtt_pass"
+nifi_emqtt_cert_dir: "/etc/ssl/certs/emqtt"
+nifi_emqtt_kestore_file_dest: "{{ nifi_emqtt_cert_dir }}/keystore.jks"
+create_mqtt_certs: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -327,4 +327,4 @@ nifi_emqtt_certificate_authority_key:
 nifi_emqtt_secure_password:
 nifi_emqtt_cert_dir:
 nifi_emqtt_kestore_file_dest:
-create_mqtt_certs: false
+nifi_create_mqtt_certs: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -322,57 +322,9 @@ nifi_java_home: /usr/lib/jvm/java-8-openjdk-amd64/jre
 nifi_all_parameter_contexts_result_file: /tmp/all_parameter_contexts_result.json
 nifi_api_base_url: http://localhost:{{ nifi_web_http_port }}/nifi-api
 nifi_parameter_contexts:
-nifi_emqtt_certificate_authority_cert: |
-  -----BEGIN CERTIFICATE-----
-  MIIDfjCCAmYCCQDUvVVl3t4gNzANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMC
-  S0UxEDAOBgNVBAgMB05haXJvYmkxEDAOBgNVBAcMB05haXJvYmkxDDAKBgNVBAoM
-  A09uYTEQMA4GA1UECwwHVGVzdGluZzEPMA0GA1UEAwwGb25hLmlvMRwwGgYJKoZI
-  hvcNAQkBFg1sc2ltYmFAb25hLmlvMB4XDTIwMDcwMzA4MTcyOVoXDTMwMDcwMTA4
-  MTcyOVowgYAxCzAJBgNVBAYTAktFMRAwDgYDVQQIDAdOYWlyb2JpMRAwDgYDVQQH
-  DAdOYWlyb2JpMQwwCgYDVQQKDANPbmExEDAOBgNVBAsMB1Rlc3RpbmcxDzANBgNV
-  BAMMBm9uYS5pbzEcMBoGCSqGSIb3DQEJARYNbHNpbWJhQG9uYS5pbzCCASIwDQYJ
-  KoZIhvcNAQEBBQADggEPADCCAQoCggEBAMA+hjOD0vRBfiIryVmC5LrUt+5Zyvok
-  xvggcZQMSi0+/7shXM1ylDGP0O/Mjsy+ITdx3XgOF19UlRzxkwib/+XKD29436M7
-  OGYKtq0C3UNMHxuZJpYCgt/vX6sJmAep4ln1LO/KE0hndy5OP+bxXb1OzmnuUIae
-  VmceyBVvXtk2hMKcypCukewp2SP1aUGYRpRLPDiMq7E/VhXaCbljqp3v7+I2GvlE
-  ONh+tdwUxqZvjk2N0clNDGEKp4peR6d6MH7aH3q3mKas8uIClbclTWwU6pMH9i2g
-  GpOk86Wo477UfWpHB/iCnESzrvuHVopsaY2pmmhlPhmH7PhounDgsBMCAwEAATAN
-  BgkqhkiG9w0BAQsFAAOCAQEAPtvx+p+sBZA9aWmhjvDsgfQA5OrcOoa/L5Tm6wdx
-  2o+88AgjON1xvIdCHOQw94z7sGbV4Ez1pj4r553HtwJGGhjrzIRtlZaMuT9LEMdr
-  DmppuM7ozyLaitciciHiYbASr0OQ0CU+7iRUFBIzjw+bJIcHDVsIk5r8WpQAbVmE
-  BMry/TefWeaWdOxjdqXFiy3oEJHZp2Y7sShMnXtCruAKGIYgZ9NAEEyfLq9VumFm
-  w1K70GVBORcJjpJQSEmSAIcX+XORzK3OkJnFmPC2/3ZdWGbuSY05bfBUc7522A3L
-  AHIfi9ba4WrMfMcBmDc8EyjHisdZPOTOc1jQh5ffgWgmQA==
-  -----END CERTIFICATE-----
-nifi_emqtt_certificate_authority_key: |
-  -----BEGIN RSA PRIVATE KEY-----
-  MIIEogIBAAKCAQEAwD6GM4PS9EF+IivJWYLkutS37lnK+iTG+CBxlAxKLT7/uyFc
-  zXKUMY/Q78yOzL4hN3HdeA4XX1SVHPGTCJv/5coPb3jfozs4Zgq2rQLdQ0wfG5km
-  lgKC3+9fqwmYB6niWfUs78oTSGd3Lk4/5vFdvU7Oae5Qhp5WZx7IFW9e2TaEwpzK
-  kK6R7CnZI/VpQZhGlEs8OIyrsT9WFdoJuWOqne/v4jYa+UQ42H613BTGpm+OTY3R
-  yU0MYQqnil5Hp3owftofereYpqzy4gKVtyVNbBTqkwf2LaAak6TzpajjvtR9akcH
-  +IKcRLOu+4dWimxpjamaaGU+GYfs+Gi6cOCwEwIDAQABAoIBAQCfGl/4/I23hwh8
-  AV8XzMO+eFRtWDUrxwpAyqEVVQKC5dPCLL9gbQaG6i6Sd+prOqPE/mC7fnYLeLYc
-  CTaV9n3X0N3rdM8pidaIZS+AipFSpApOzfZoSlXEPZkgtcTz+r6Rkt8I6WYCE1dI
-  pIwwduwMw88DTq+oahy6JXiUfOKzwwLgYP1J9XNWtAJ+jgkR18zEMgrOTLEfs08m
-  IOqgDRIuMI+OidjAnB6C+LizIHu3dYagT1PrhVOiO1gIZeKhb+g47XJkyMMpAJ9o
-  knCe/0feT9DYB1LCK/XmHjP4FsPbWxI0LDIwKGT411EUdWMifkU7fESa9IHmEok8
-  bAzNR3nxAoGBAOJBP8wbqTYfKmUCWjqQEhwQW399iVNjETDxWsJAZqOf1rjKziaV
-  bUV16t/+40wL42yUzA1vPFTymV/AIvW3NSMLYVQ9aTNfcbmknf3npJrdRJtEvIiS
-  OQHtmRPofdo//poLUQc5AIY2uON3j8OQaeHBYvNlSLZ0TS1YtbShob0pAoGBANmE
-  oBQrLhqJ5hkAoEbiHZXguso5E/O82DTtq8xI3vX1GCBI3kLU7r9lPjunLuNyLpy4
-  x90smj9es6/+/Zf+aGpPaLY8LDgtLI/R4VLXj1pvebMlRNcaUiKVYoQQW1N+IfDy
-  5LLAOQqHEiAl8NOf/bBuq2bjH94Ty28htgJhoq7bAn8vuZO7eho3UFug8t4VfE5V
-  nR2vxsswy7TUnhSG5Q7BdPXWBPF3Mg3amQTyOtG3OMrAHKLuMoiHYqT3jY/SRNLw
-  kXX2Tv3h2EAk6JRq+nG+OO4/0j/yjuV3gqbHjEL/xn/t/nUZEO0LYn+de5rXpZ6w
-  ABrfPH4Z/m5JIm0xrOZxAoGAMQghYYp+QQM2uAoZFwFfc+qNkIofQkEeZ4fvwwPm
-  JoFSJ+zlFSGUk9ZJmf7Mpf6WHUPV4bhtKL27OX/8QCfb96Lg0rtrqFoegmjoJtlq
-  ehNI1qYfB3Hqc9tCssxRGdgD5KGMBfMoqIPcBR0oVTvqXrwDrRSjmVbS88EgmxbR
-  KiMCgYEArYUgbHqQypaq/WE2Dln32WeDPhbFjg2s6fOqiWsLx6cJk+N7cCz3/Wpm
-  yhAW+v3qWPQpnaCVkF3kgqViRX2AKWITBn2G/vktlHwj2FCJq3Q8quWacokE5EFZ
-  nOFJoIuOBE2Vx0fmGOru4tDSnXxbqRUqkuieAEaQ4028B1nGTXc=
-  -----END RSA PRIVATE KEY-----
-nifi_emqtt_secure_password: "emqtt_pass"
-nifi_emqtt_cert_dir: "/etc/ssl/certs/emqtt"
-nifi_emqtt_kestore_file_dest: "{{ nifi_emqtt_cert_dir }}/keystore.jks"
-create_mqtt_certs: true
+nifi_emqtt_certificate_authority_cert:
+nifi_emqtt_certificate_authority_key:
+nifi_emqtt_secure_password:
+nifi_emqtt_cert_dir:
+nifi_emqtt_kestore_file_dest:
+create_mqtt_certs: false

--- a/molecule/certs/INSTALL.rst
+++ b/molecule/certs/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/certs/converge.yml
+++ b/molecule/certs/converge.yml
@@ -8,11 +8,11 @@
         update_cache: yes
         state: present
 
-    - name: "Generate key for client certificate"
+    - name: "Generate key for root certificate"
       command: openssl genrsa -out /tmp/MyRootCA.key 2048
       changed_when: false
 
-    - name: "Issue certificate for client"
+    - name: "Issue root certificate"
       command: openssl req -x509 -new -nodes -key /tmp/MyRootCA.key -sha256 -days 3650 -out /tmp/MyRootCA.pem
       changed_when: false
 
@@ -20,7 +20,7 @@
   roles:
     - role: nifi
       vars:
-        create_mqtt_certs: true
+        nifi_create_mqtt_certs: true
         nifi_emqtt_certificate_authority_cert: "{{ lookup('file', '/tmp/MyRootCA.pem') }}"
         nifi_emqtt_certificate_authority_key: "{{ lookup('file', '/tmp/MyRootCA.key') }}"
         nifi_emqtt_secure_password: "password"

--- a/molecule/certs/converge.yml
+++ b/molecule/certs/converge.yml
@@ -1,0 +1,28 @@
+---
+- name: Converge
+  hosts: all
+  pre_tasks:
+    - name: Install networking tools needed for testing running service
+      apt:
+        name: net-tools
+        update_cache: yes
+        state: present
+
+    - name: "Generate key for client certificate"
+      command: openssl genrsa -out /tmp/MyRootCA.key 2048
+      changed_when: false
+
+    - name: "Issue certificate for client"
+      command: openssl req -x509 -new -nodes -key /tmp/MyRootCA.key -sha256 -days 3650 -out /tmp/MyRootCA.pem
+      changed_when: false
+
+
+  roles:
+    - role: nifi
+      vars:
+        create_mqtt_certs: true
+        nifi_emqtt_certificate_authority_cert: "{{ lookup('file', '/tmp/MyRootCA.pem') }}"
+        nifi_emqtt_certificate_authority_key: "{{ lookup('file', '/tmp/MyRootCA.key') }}"
+        nifi_emqtt_secure_password: "password"
+        nifi_emqtt_cert_dir: "/etc/ssl/certs/emqtt"
+        nifi_emqtt_kestore_file_dest: "{{ nifi_emqtt_cert_dir }}/keystore.jks"

--- a/molecule/certs/converge.yml
+++ b/molecule/certs/converge.yml
@@ -13,14 +13,14 @@
       changed_when: false
 
     - name: "Issue root certificate"
-      command: openssl req -x509 -new -nodes -key /tmp/MyRootCA.key -sha256 -days 3650 -out /tmp/MyRootCA.pem
+      command: openssl req -x509 -new -nodes -key /tmp/MyRootCA.key -sha256 -days 3650 -out /tmp/MyRootCA.pem -subj "{{ certificate_attributes }}"
       changed_when: false
 
 
   roles:
     - role: nifi
       vars:
-        nifi_create_mqtt_certs: true
+        nifi_create_mqtt_certs: false
         nifi_emqtt_certificate_authority_cert: "{{ lookup('file', '/tmp/MyRootCA.pem') }}"
         nifi_emqtt_certificate_authority_key: "{{ lookup('file', '/tmp/MyRootCA.key') }}"
         nifi_emqtt_secure_password: "password"

--- a/molecule/certs/converge.yml
+++ b/molecule/certs/converge.yml
@@ -16,13 +16,22 @@
       command: openssl req -x509 -new -nodes -key /tmp/MyRootCA.key -sha256 -days 3650 -out /tmp/MyRootCA.pem -subj "{{ certificate_attributes }}"
       changed_when: false
 
+    - name: "Read certificate key"
+      command: cat /tmp/MyRootCA.key
+      register: certificate_key
+      changed_when: false
+
+    - name: "Read CA cert"
+      command: cat /tmp/MyRootCA.pem
+      register: ca_cert
+      changed_when: false
 
   roles:
     - role: nifi
       vars:
-        nifi_create_mqtt_certs: false
-        nifi_emqtt_certificate_authority_cert: "{{ lookup('file', '/tmp/MyRootCA.pem') }}"
-        nifi_emqtt_certificate_authority_key: "{{ lookup('file', '/tmp/MyRootCA.key') }}"
+        nifi_create_mqtt_certs: true
+        nifi_emqtt_certificate_authority_cert: "{{ ca_cert.stdout }}"
+        nifi_emqtt_certificate_authority_key: "{{ certificate_key.stdout }}"
         nifi_emqtt_secure_password: "password"
         nifi_emqtt_cert_dir: "/etc/ssl/certs/emqtt"
         nifi_emqtt_kestore_file_dest: "{{ nifi_emqtt_cert_dir }}/keystore.jks"

--- a/molecule/certs/molecule.yml
+++ b/molecule/certs/molecule.yml
@@ -1,0 +1,34 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: ubuntu-16.04
+    image: solita/ubuntu-systemd:16.04
+    privileged: true
+    command: /sbin/init
+    network_mode: host
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: ansible
+scenario:
+  name: certs
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - side_effect
+    - verify
+    - destroy

--- a/molecule/certs/requirements.yml
+++ b/molecule/certs/requirements.yml
@@ -1,0 +1,3 @@
+---
+- role: geerlingguy.java
+- role: Stouts.backup

--- a/molecule/certs/tests/test_certs.py
+++ b/molecule/certs/tests/test_certs.py
@@ -1,0 +1,16 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_ensure_emqtt_cert_directories_are_present(host):
+    certs_dir = host.file("/etc/ssl/certs/emqtt")
+    assert certs_dir.exists
+    assert certs_dir.is_directory
+
+
+def test_ensure_emqtt_certs_are_present(host):
+    certs = host.file("/etc/ssl/certs/emqtt/keystore.jks")
+    assert certs.exists

--- a/molecule/certs/verify.yml
+++ b/molecule/certs/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/molecule/certs/verify.yml
+++ b/molecule/certs/verify.yml
@@ -1,9 +1,0 @@
----
-# This is an example playbook to execute Ansible tests.
-
-- name: Verify
-  hosts: all
-  tasks:
-  - name: Example assertion
-    assert:
-      that: true

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -44,13 +44,21 @@
   ignore_errors: yes  # this will fail if already imported, ignore that failure
   tags: [ config, security ]
 
+- name: Ensure cert directories are present
+  file:
+    state: directory
+    owner: "{{ nifi_user }}"
+    group: www-data
+    path: "{{ nifi_emqtt_cert_dir }}"
+
 - name: Create mqtt SSL Cerificates
   java_keystore:
     name: certificates
-    certificate: "{{ emqtt_certificate_authority_cert }}"
-    private_key: "{{ emqtt_certificate_authority_key }}"
-    password: "{{ emqtt_secure_password }}"
-    dest: "{{ emqtt_kestore_file_dest }}"
+    certificate: "{{ nifi_emqtt_certificate_authority_cert }}"
+    private_key: "{{ nifi_emqtt_certificate_authority_key }}"
+    password: "{{ nifi_emqtt_secure_password }}"
+    dest: "{{ nifi_emqtt_kestore_file_dest }}"
+  when: create_mqtt_certs
 
 - name: Ensure NiFi owns key files
   file:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -58,7 +58,7 @@
     private_key: "{{ nifi_emqtt_certificate_authority_key }}"
     password: "{{ nifi_emqtt_secure_password }}"
     dest: "{{ nifi_emqtt_kestore_file_dest }}"
-  when: create_mqtt_certs
+  when: nifi_create_mqtt_certs
 
 - name: Ensure NiFi owns key files
   file:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -50,6 +50,7 @@
     owner: "{{ nifi_user }}"
     group: www-data
     path: "{{ nifi_emqtt_cert_dir }}"
+  when: nifi_create_mqtt_certs
 
 - name: Create mqtt SSL Cerificates
   java_keystore:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -44,6 +44,14 @@
   ignore_errors: yes  # this will fail if already imported, ignore that failure
   tags: [ config, security ]
 
+- name: Create mqtt SSL Cerificates
+  java_keystore:
+    name: certificates
+    certificate: "{{ emqtt_certificate_authority_cert }}"
+    private_key: "{{ emqtt_certificate_authority_key }}"
+    password: "{{ emqtt_secure_password }}"
+    dest: "{{ emqtt_kestore_file_dest }}"
+
 - name: Ensure NiFi owns key files
   file:
     owner: "{{ nifi_user }}"


### PR DESCRIPTION
Use java_keystore to generate .jks keystore.
This is required for communication to the emqtt server.